### PR TITLE
Add Morepath webframework

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [web.py](http://webpy.org/) - A web framework for Python that is as simple as it is powerful.
 * [web2py](http://www.web2py.com) - A full stack web framework and platform focused in the ease of use.
 * [Tornado](http://www.tornadoweb.org/en/latest/) - A Web framework and asynchronous networking library.
+* [Morepath](https://github.com/morepath/morepath) - A fast, flexibile and expressive web framework.
 
 ## Serverless Frameworks
 


### PR DESCRIPTION
## Why this framework/library/software/resource is awesome?

Morepath is a Python web framework. An application consists of models. Each type of model is published on a URL path. Content is exposed to the web using views.
## Vote for this pull request

Who agrees that this change should be merged could add your reactions (e.g. :+1:) to this pull request.

Added morepath webframework
